### PR TITLE
broken version

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
     return callback();
   }
 
-  let config = {
+  const config = {
     host: args.host,
     port: args.port || 22,
     username: args.user,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const deploy = require("sftp-sync-deploy");
+const { deploy } = require('sftp-sync-deploy');
 
 hexo.extend.deployer.register("sftp", function(args, callback) {
   if (!args.host || !args.user) {
@@ -26,7 +26,7 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
     return callback();
   }
 
-  const config = {
+  let config = {
     host: args.host,
     port: args.port || 22,
     username: args.user,
@@ -38,20 +38,19 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
     remoteDir: args.remotePath || "/"
   };
 
-  const options = {
-    dryRun: !!args.dryrun,
-    forceUpload: args.forceUpload
+  let options = {
+    dryRun: false,
+    forceUpload: args.forceUpload,
+    excludeMode: 'remove',
+    concurrency: 100
     // exclude: [                      // exclude patterns (glob)
     //   'node_modules',
     //   'src/**/*.spec.ts'
     // ]
   };
 
-  deploy(config, options)
-    .then(() => {
-      callback();
-    })
-    .catch(err => {
-      callback(err);
-    });
+deploy(config, options).then(() => {
+  console.log('Deployed!');
+}).catch(err => {
+  console.error('error! ', err);
 });

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
     remoteDir: args.remotePath || "/"
   };
 
-  let options = {
+  const options = {
     dryRun: false,
     forceUpload: args.forceUpload,
     excludeMode: 'remove',

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
   };
 
   deploy(config, options).then(() => {
-    console.log('Deployed!');
+    callback();
   }).catch(err => {
     console.error('error! ', err);
   });

--- a/index.js
+++ b/index.js
@@ -49,8 +49,9 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
     // ]
   };
 
-deploy(config, options).then(() => {
-  console.log('Deployed!');
-}).catch(err => {
-  console.error('error! ', err);
+  deploy(config, options).then(() => {
+    console.log('Deployed!');
+  }).catch(err => {
+    console.error('error! ', err);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
   };
 
   const options = {
-    dryRun: false,
+    dryRun: !!args.dryrun,
     forceUpload: args.forceUpload,
     excludeMode: 'remove',
     concurrency: 100

--- a/index.js
+++ b/index.js
@@ -52,6 +52,6 @@ hexo.extend.deployer.register("sftp", function(args, callback) {
   deploy(config, options).then(() => {
     callback();
   }).catch(err => {
-    console.error('error! ', err);
+    callback(err);
   });
 });


### PR DESCRIPTION
With 0.3.0

![image](https://user-images.githubusercontent.com/16578570/75178333-30fea000-5738-11ea-80e4-ed6dd6c1973f.png)

it may be due to the new syntax

see https://github.com/dobbydog/sftp-sync-deploy/commit/76e0d776f1a0e9f0aa5b17fb3a8fb36574d09e53

With the fix:

![image](https://user-images.githubusercontent.com/16578570/75179354-3361f980-573a-11ea-9911-e006ce75015b.png)

My bad I forgot it. We're good for a v0.4.0.

